### PR TITLE
Fix GitHub Pages routing by honoring Vite base URL

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -10,26 +10,29 @@ import { getConfig } from '../lib/config';
 
 const { site } = getConfig();
 
-export const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <App />,
-    children: site.pages.map((p) => {
-      switch (p.sectionsKey) {
-        case 'home':
-          return { index: true, element: <Home /> } as const;
-        case 'services':
-          return { path: p.path.replace(/^\//, ''), element: <Services /> } as const;
-        case 'work':
-          return { path: p.path.replace(/^\//, ''), element: <Work /> } as const;
-        case 'reviews':
-          return { path: p.path.replace(/^\//, ''), element: <Reviews /> } as const;
-        case 'contact':
-          return { path: p.path.replace(/^\//, ''), element: <Contact /> } as const;
-        default:
-          return { path: p.path.replace(/^\//, ''), element: <Home /> } as const;
-      }
-    })
-  }
-]);
+export const router = createBrowserRouter(
+  [
+    {
+      path: '/',
+      element: <App />,
+      children: site.pages.map((p) => {
+        switch (p.sectionsKey) {
+          case 'home':
+            return { index: true, element: <Home /> } as const;
+          case 'services':
+            return { path: p.path.replace(/^\//, ''), element: <Services /> } as const;
+          case 'work':
+            return { path: p.path.replace(/^\//, ''), element: <Work /> } as const;
+          case 'reviews':
+            return { path: p.path.replace(/^\//, ''), element: <Reviews /> } as const;
+          case 'contact':
+            return { path: p.path.replace(/^\//, ''), element: <Contact /> } as const;
+          default:
+            return { path: p.path.replace(/^\//, ''), element: <Home /> } as const;
+        }
+      })
+    }
+  ],
+  { basename: import.meta.env.BASE_URL }
+);
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- configure the React Router instance with the deployment base URL so routes resolve on GitHub Pages
- add the Vite environment declaration file so TypeScript recognizes `import.meta.env`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9f12fa1d0833395d014a25790a70c